### PR TITLE
add admin support + configurator + ingredient fetch and edit

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,10 @@
-import React from "react";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
+import Configurator from "./modules/admin/components/Configurator";
 import Login from "./modules/auth/components/Login";
 import Signup from "./modules/auth/components/Signup";
 import Browse from "./modules/browse/components/Browse";
 import Dashboard from "./modules/dashboard/components/Dashboard";
+import { Routes } from "./modules/general/utils/routes";
 import AppBar from "./modules/navigation/components/AppBar";
 
 export default function App() {
@@ -11,17 +12,21 @@ export default function App() {
     <Router>
       <div>
         <Switch>
-          <Route path="/signup" exact>
+          <Route path={Routes.signup} exact>
             <Signup />
           </Route>
-          <Route path="/login" exact>
+          <Route path={Routes.login} exact>
             <Login />
           </Route>
-          <Route path="/browse" exact>
+          <Route path={Routes.customerBrowse} exact>
             <AppBar />
             <Browse />
           </Route>
-          <Route path="/" exact>
+          <Route path={Routes.adminConfigurator} exact>
+            <AppBar />
+            <Configurator />
+          </Route>
+          <Route path={Routes.customerDashboard} exact>
             <AppBar />
             <Dashboard />
           </Route>

--- a/src/modules/admin/components/Configurator.tsx
+++ b/src/modules/admin/components/Configurator.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect } from "react";
+import { Container, Box, Tabs, Tab, Typography } from "@mui/material";
+import Ingredients from "./Ingredients/Ingredients";
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+function TabPanel(props: TabPanelProps) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      {...other}
+    >
+      {value === index && (
+        <Box sx={{ p: 3 }}>
+          <Typography>{children}</Typography>
+        </Box>
+      )}
+    </div>
+  );
+}
+
+function a11yProps(index: number) {
+  return {
+    id: `simple-tab-${index}`,
+    "aria-controls": `simple-tabpanel-${index}`,
+  };
+}
+
+export default function Configurator() {
+  const [value, setValue] = React.useState(0);
+
+  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+    setValue(newValue);
+  };
+
+  return (
+    <Container maxWidth="xl">
+      <h1>Configurator</h1>
+      <Box sx={{ width: "100%" }}>
+        <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+          <Tabs
+            value={value}
+            onChange={handleChange}
+            aria-label="basic tabs example"
+          >
+            <Tab label="Ingredients" {...a11yProps(0)} />
+            <Tab label="Meals" {...a11yProps(1)} />
+            <Tab label="Diets" {...a11yProps(2)} />
+          </Tabs>
+        </Box>
+        <TabPanel value={value} index={0}>
+          <Ingredients />
+        </TabPanel>
+        <TabPanel value={value} index={1}>
+          Meals
+        </TabPanel>
+        <TabPanel value={value} index={2}>
+          Diets
+        </TabPanel>
+      </Box>
+    </Container>
+  );
+}

--- a/src/modules/admin/components/Ingredients/Ingredients.tsx
+++ b/src/modules/admin/components/Ingredients/Ingredients.tsx
@@ -1,0 +1,132 @@
+import React, { useEffect } from "react";
+import {
+  Button,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  Modal,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Box } from "@mui/system";
+import { Ingredient } from "../../../general/types/ingredient";
+import { getIngredients, updateIngredient } from "../../../general/utils/utils";
+import EditIcon from "@mui/icons-material/Edit";
+
+const editIngredientModalStyle = {
+  position: "absolute" as "absolute",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  width: 400,
+  bgcolor: "white",
+  border: "2px solid #000",
+  boxShadow: 24,
+  p: 4,
+};
+
+export default function Ingredients() {
+  const [ingredients, setIngredients] = React.useState<
+    Ingredient[] | undefined
+  >(undefined);
+  const [editIngredient, setEditIngredient] = React.useState<Ingredient | null>(
+    null
+  );
+  const [ingredientNewName, setIngredientNewName] = React.useState<
+    string | null
+  >(null);
+
+  const loadIngredients = async () => {
+    const ingredients = await getIngredients();
+    setIngredients(ingredients);
+  };
+
+  useEffect(() => {
+    loadIngredients();
+  });
+
+  const handleIngredientSave = async () => {
+    if (!editIngredient || !ingredientNewName) {
+      return;
+    }
+    const ingredientId = await updateIngredient(
+      editIngredient.id,
+      ingredientNewName
+    );
+
+    if (ingredientId) {
+      setEditIngredient(null);
+      setIngredientNewName(null);
+    } else {
+      alert("Couldn't save ingredient. Please try again later.");
+    }
+  };
+
+  return (
+    <>
+      <List>
+        {ingredients &&
+          ingredients.map((ingredient, index) => {
+            return (
+              <ListItem
+                key={`ingredient-${index}-id`}
+                secondaryAction={
+                  <IconButton
+                    edge="end"
+                    aria-label="delete"
+                    onClick={() => setEditIngredient(ingredient)}
+                  >
+                    <EditIcon />
+                  </IconButton>
+                }
+              >
+                <ListItemText
+                  primary={ingredient.name}
+                  secondary={ingredient.id}
+                />
+              </ListItem>
+            );
+          })}
+      </List>
+      <Modal
+        open={Boolean(editIngredient)}
+        onClose={() => setEditIngredient(null)}
+        aria-labelledby="edit-ingredient-modal"
+      >
+        <Box sx={editIngredientModalStyle}>
+          <Typography id="modal-modal-title" variant="h6" component="h2">
+            {editIngredient?.name}
+          </Typography>
+          <Typography id="modal-modal-subtitle" variant="subtitle2">
+            {editIngredient?.id}
+          </Typography>
+          <TextField
+            id="edit-ingredient-name-input"
+            label="New name"
+            variant="outlined"
+            required
+            type="text"
+            sx={{
+              width: "100%",
+              margin: "16px 0px 16px 0px",
+              boxSizing: "border-box",
+            }}
+            value={ingredientNewName}
+            onChange={(event) => setIngredientNewName(event.target.value)}
+          />
+          <Box sx={{ justifyContent: "flex-end", display: "flex" }}>
+            <Button
+              variant="contained"
+              sx={{ alignSelf: "flex-end" }}
+              onClick={handleIngredientSave}
+              disabled={!ingredientNewName}
+            >
+              Save
+            </Button>
+          </Box>
+        </Box>
+      </Modal>
+    </>
+  );
+}

--- a/src/modules/auth/components/Login.tsx
+++ b/src/modules/auth/components/Login.tsx
@@ -1,6 +1,7 @@
 import { Container, Grid, Typography } from "@mui/material";
 import { useEffect } from "react";
 import { useHistory } from "react-router";
+import { Routes } from "../../general/utils/routes";
 import LoginForm from "./LoginForm";
 
 export default function Login() {
@@ -9,7 +10,7 @@ export default function Login() {
   useEffect(() => {
     const user = localStorage.getItem("user");
     if (user) {
-      browserHistory.push("/");
+      browserHistory.push(Routes.customerDashboard);
     }
   });
 
@@ -31,7 +32,7 @@ export default function Login() {
                 Don't have an account yet?
               </Typography>
               <Typography textAlign="center">
-                Sign up <a href="/signup">here</a>
+                Sign up <a href={Routes.signup}>here</a>
               </Typography>
             </div>
           </Grid>

--- a/src/modules/auth/components/LoginForm.tsx
+++ b/src/modules/auth/components/LoginForm.tsx
@@ -8,6 +8,7 @@ import { TextField } from "@mui/material";
 import { emailRegex } from "../utils/regex";
 import { URLs } from "../../general/utils/urls";
 import { useHistory } from "react-router";
+import { Routes } from "../../general/utils/routes";
 
 export default function LoginForm() {
   const [email, setEmail] = useState<string | undefined>(undefined);
@@ -38,7 +39,11 @@ export default function LoginForm() {
           alert("Error. Usuario inválido.");
         } else {
           localStorage.setItem("user", JSON.stringify(data));
-          browserHistory.push("/");
+          if (data.type === "Customer") {
+            browserHistory.push(Routes.customerDashboard);
+          } else {
+            browserHistory.push(Routes.adminConfigurator);
+          }
         }
       });
   };

--- a/src/modules/auth/components/Signup.tsx
+++ b/src/modules/auth/components/Signup.tsx
@@ -1,6 +1,7 @@
 import { Container, Grid, Typography } from "@mui/material";
 import { useEffect } from "react";
 import { useHistory } from "react-router";
+import { Routes } from "../../general/utils/routes";
 import SignupForm from "./SignupForm";
 
 export default function Signup() {
@@ -9,7 +10,7 @@ export default function Signup() {
   useEffect(() => {
     const user = localStorage.getItem("user");
     if (user) {
-      browserHistory.push("/");
+      browserHistory.push(Routes.customerDashboard);
     }
   });
 
@@ -31,7 +32,7 @@ export default function Signup() {
                 Already have an account?
               </Typography>
               <Typography textAlign="center">
-                Log in <a href="/login">here</a>
+                Log in <a href={Routes.login}>here</a>
               </Typography>
             </div>
           </Grid>

--- a/src/modules/auth/components/SignupForm.tsx
+++ b/src/modules/auth/components/SignupForm.tsx
@@ -8,6 +8,7 @@ import { TextField } from "@mui/material";
 import { emailRegex } from "../utils/regex";
 import { URLs } from "../../general/utils/urls";
 import { useHistory } from "react-router";
+import { Routes } from "../../general/utils/routes";
 
 export default function SignupForm() {
   const [firstName, setFirstName] = useState<string | undefined>(undefined);
@@ -77,7 +78,11 @@ export default function SignupForm() {
           alert("Error. Usuario ya existe.");
         } else {
           localStorage.setItem("user", JSON.stringify(data));
-          browserHistory.push("/");
+          if (data.type === "Customer") {
+            browserHistory.push(Routes.customerDashboard);
+          } else {
+            browserHistory.push(Routes.adminConfigurator);
+          }
         }
       })
       .catch(() => {

--- a/src/modules/general/types/ingredient.tsx
+++ b/src/modules/general/types/ingredient.tsx
@@ -1,0 +1,9 @@
+export interface Ingredient {
+  id: string;
+  name: string;
+}
+
+export interface IngredientResponse {
+  pagesNumber: number;
+  pagination: [Ingredient];
+}

--- a/src/modules/general/utils/routes.tsx
+++ b/src/modules/general/utils/routes.tsx
@@ -1,0 +1,8 @@
+export const Routes = {
+  login: "/login",
+  signup: "/signup",
+  customerDashboard: "/dashboard",
+  customerBrowse: "/browse",
+  account: "/account",
+  adminConfigurator: "/admin/configurator",
+};

--- a/src/modules/general/utils/utils.tsx
+++ b/src/modules/general/utils/utils.tsx
@@ -1,0 +1,27 @@
+import { Ingredient, IngredientResponse } from "../types/ingredient";
+
+import axios from "axios";
+
+export const getIngredients = async (): Promise<Ingredient[]> => {
+  const response = await axios.get(
+    "http://algofit-qa-alb-599938117.us-east-1.elb.amazonaws.com/ingredient?Page=1&PageSize=100"
+  );
+  const data = response.data as IngredientResponse;
+  return data.pagination;
+};
+
+export const updateIngredient = async (
+  id: string,
+  newName: string
+): Promise<string | null> => {
+  try {
+    await axios.put(
+      "http://algofit-qa-alb-599938117.us-east-1.elb.amazonaws.com/ingredient/" +
+        id,
+      { name: newName }
+    );
+    return id;
+  } catch (e) {
+    return null;
+  }
+};

--- a/src/modules/navigation/components/AccountMenu.tsx
+++ b/src/modules/navigation/components/AccountMenu.tsx
@@ -12,6 +12,7 @@ import Tooltip from "@mui/material/Tooltip";
 import Settings from "@mui/icons-material/Settings";
 import Logout from "@mui/icons-material/Logout";
 import { User } from "../../general/types/user";
+import { Routes } from "../../general/utils/routes";
 
 export default function AccountMenu(user: User) {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
@@ -26,7 +27,7 @@ export default function AccountMenu(user: User) {
   const browserHistory = useHistory();
   const handleLogout = () => {
     localStorage.removeItem("user");
-    browserHistory.push("/");
+    browserHistory.push(Routes.customerBrowse);
     window.location.reload()
   };
 

--- a/src/modules/navigation/components/AppBar.tsx
+++ b/src/modules/navigation/components/AppBar.tsx
@@ -2,7 +2,7 @@ import AppBar from "@mui/material/AppBar";
 import Box from "@mui/material/Box";
 import Toolbar from "@mui/material/Toolbar";
 import Button from "@mui/material/Button";
-import { NavTabs } from "./Tabs";
+import NavTabs from "./Tabs";
 import { useHistory } from "react-router";
 import { useEffect, useState } from "react";
 import { User } from "../../general/types/user";
@@ -34,7 +34,7 @@ export default function CustomAppBar() {
     <Box sx={{ flexGrow: 1 }}>
       <AppBar position="static" style={{ backgroundColor: "white" }}>
         <Toolbar>
-          <NavTabs />
+          <NavTabs userType={user?.type} />
           {user ? (
             <AccountMenu {...user} />
           ) : (

--- a/src/modules/navigation/components/Tabs.tsx
+++ b/src/modules/navigation/components/Tabs.tsx
@@ -1,12 +1,55 @@
-import * as React from "react";
 import Box from "@mui/material/Box";
 import { Button } from "@mui/material";
+import { Routes } from "../../general/utils/routes";
 
-export function NavTabs() {
-  return (
-    <Box sx={{ width: "100%" }}>
-      <Button title="Dashboard" href="/" color="primary">Dashboard</Button>
-      <Button title="Browse" href="/browse" color="primary">Browse</Button>
-    </Box>
-  );
+interface NavTabsProps {
+  userType: string | undefined;
 }
+
+function NavTabs(props: NavTabsProps) {
+  const customerTabs = (
+    <>
+      <Button title="Dashboard" href={Routes.customerDashboard} color="primary">
+        Dashboard
+      </Button>
+      <Button title="Browse" href={Routes.customerBrowse} color="primary">
+        Browse
+      </Button>
+    </>
+  );
+
+  const adminTabs = (
+    <>
+      <Button
+        title="Configurator"
+        href={Routes.adminConfigurator}
+        color="primary"
+      >
+        Configurator
+      </Button>
+    </>
+  );
+
+  const defaultTabs = (
+    <>
+      <Button title="Browse" href={Routes.customerBrowse} color="primary">
+        Browse
+      </Button>
+    </>
+  );
+
+  const renderTabs = () => {
+    switch (props.userType) {
+      case "Customer":
+        return customerTabs;
+      case "Admin":
+        return adminTabs;
+      default:
+        return defaultTabs;
+    }
+  };
+
+  return <Box sx={{ width: "100%" }}>{renderTabs()}</Box>;
+}
+
+export default NavTabs;


### PR DESCRIPTION
# Description

Add admin user type support with a Configurator page and the ability to view and edit ingredients

## Evidence

https://user-images.githubusercontent.com/11319430/140437145-6a202888-c19b-4c2e-bc10-5150921fc6d5.mov

# Type of change

Please select one of the following or add your own type of change.

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Redesign
- [ ] Other
